### PR TITLE
Added test for language prefix with dash

### DIFF
--- a/i18n_patterns_test/tests.py
+++ b/i18n_patterns_test/tests.py
@@ -12,6 +12,10 @@ class IndexTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.wsgi_request.LANGUAGE_CODE, 'de')
 
+        response = self.client.get('/de-test-parking/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.wsgi_request.LANGUAGE_CODE, 'en')
+
         response = self.client.get('/pl/test-parking/')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.wsgi_request.LANGUAGE_CODE, 'pl')


### PR DESCRIPTION
Hello - I work with Keith Hackbarth who originally created the ticket here: https://code.djangoproject.com/ticket/27063

I added a test for the case in which the language code is prefixed with a - ('/de-test-parking') and the tests pass with your changes and new language_code_prefix_re. 

Thanks for your help!
